### PR TITLE
[deprecated] Add plot recipe for Plots.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,14 @@ version = "0.2.4-pre"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 GR = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]

--- a/src/Trixi2Img.jl
+++ b/src/Trixi2Img.jl
@@ -6,6 +6,7 @@ using Glob: glob
 using HDF5: h5open, attributes, haskey
 using Plots: plot, plot!, gr, savefig, contourf!
 using Requires
+using StaticArrays
 using TimerOutputs
 import GR
 
@@ -32,6 +33,8 @@ end
 
 # export types/functions that define the public API of Trixi2Img
 export trixi2img
+
+export ContourPlot
 
 end # module Trixi2Img
 

--- a/src/Trixi2Img.jl
+++ b/src/Trixi2Img.jl
@@ -5,6 +5,7 @@ using EllipsisNotation
 using Glob: glob
 using HDF5: h5open, attributes, haskey
 using Plots: plot, plot!, gr, savefig, contourf!
+using Requires
 using TimerOutputs
 import GR
 
@@ -23,6 +24,11 @@ include("io.jl")
 
 # Include top-level conversion method
 include("convert.jl")
+
+# Add plot recipes based on availability of the Trixi package
+function __init__()
+  @require Trixi="a7f1ee26-1774-49b1-8366-f1abc58fbfcb" include("plot_recipes.jl")
+end
 
 # export types/functions that define the public API of Trixi2Img
 export trixi2img

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -2,125 +2,113 @@ using RecipesBase
 using DiffEqBase
 import .Trixi
 
-struct TrixiPlot{RealT, SolutionT, SemidiscretizationT<:Trixi.AbstractSemidiscretization}
-  u::SolutionT
-  semi::SemidiscretizationT
-  time::RealT
+
+struct ContourPlot{Coordinates, Data, Variables, Limits, Vertices}
+  x::Coordinates
+  y::Coordinates
+  data::Data
+  variables::Variables
+  xlims::Limits
+  ylims::Limits
+  vertices_x::Vertices
+  vertices_y::Vertices
 end
 
-TrixiPlot(u, prob::ODEProblem, time=NaN) = TrixiPlot(Trixi.wrap_array(u, prob.p), prob.p, time)
-TrixiPlot(u, sol::ODESolution, time=NaN) = TrixiPlot(Trixi.wrap_array(u, sol.prob.p), sol.prob.p, time)
-TrixiPlot(sol::ODESolution) = TrixiPlot(Trixi.wrap_array(sol.u[end], sol.prob.p), sol.prob.p, sol.t[end])
-TrixiPlot(u, ::Trixi.SemidiscretizationEulerGravity) = error("not implemented")
+function ContourPlot(sol::ODESolution;
+                     grid_lines=true, max_supported_level=11, nvisnodes=nothing,
+                     slice_axis=:z, slice_axis_intercept=0,
+                     solution_variables=Trixi.cons2cons)
+  # Extract basic information about Trixi's solution
+  semi = sol.prob.p
+  u = Trixi.wrap_array(sol.u[end], semi)
+  mesh, equations, solver, cache = Trixi.mesh_equations_solver_cache(semi)
+  ndims = Trixi.ndims(mesh)
+  @assert ndims in (2, 3) "unsupported number of dimensions $ndims (must be 2 or 3)"
 
-function Base.show(io::IO, tp::TrixiPlot)
-  print(io, "TrixiPlot(...)")
-end
-
-@recipe function f(tp::TrixiPlot; grid_lines=false, max_supported_level=11, nvisnodes=nothing,
-                                  slice_axis=:z, slice_axis_intercept=0)
-  # Extract basic information from solution
-  mesh, equations, solver, cache = Trixi.mesh_equations_solver_cache(tp.semi)
-
+  # Extract mesh info
   center_level_0 = mesh.tree.center_level_0
   length_level_0 = mesh.tree.length_level_0
   leaf_cells = Trixi.leaf_cells(mesh.tree)
   coordinates = mesh.tree.coordinates[:, leaf_cells]
   levels = mesh.tree.levels[leaf_cells]
-  ndims = Trixi.ndims(mesh)
 
-  labels = Array{String}(undef, 1, Trixi.nvariables(equations))
-  labels[1, :] .= Trixi.varnames(Trixi.cons2cons, equations)
-  if ndims == 3
-    # Read 3d data
-    data = Array{Float64}(undef, Trixi.nnodes(solver), Trixi.nnodes(solver), Trixi.nnodes(solver),
-                          Trixi.nelements(solver, cache), Trixi.nvariables(equations))
-  elseif ndims == 2
-    # Read 2d data
-    data = Array{Float64}(undef, Trixi.nnodes(solver), Trixi.nnodes(solver),
-                          Trixi.nelements(solver, cache), Trixi.nvariables(equations))
-  else
-    error("unsupported number of dimensions: $ndims")
-  end
-  for variable in Trixi.eachvariable(equations)
-    @views data[.., :, variable] .= tp.u[variable, .., :]
-  end
-  n_nodes = Trixi.nnodes(solver)
-  time = 0.0
-
-  # Calculate x and y limits
+  unstructured_data = get_unstructured_data(u, semi, solution_variables)
+  x, y, data, vertices_x, vertices_y = get_contour_data(center_level_0, length_level_0, leaf_cells,
+                                                        coordinates, levels, ndims,
+                                                        unstructured_data, Trixi.nnodes(solver),
+                                                        grid_lines, max_supported_level, nvisnodes,
+                                                        slice_axis, slice_axis_intercept)
+  variables = SVector(Trixi.varnames(solution_variables, equations))
   xlims = (-1, 1) .* (length_level_0/2 + center_level_0[1])
   ylims = (-1, 1) .* (length_level_0/2 + center_level_0[2])
 
-  # Determine axis labels
-  if ndims == 3
-    # Extract plot labels
-    if slice_axis === :x
-      xlabel = "y"
-      ylabel = "z"
-    elseif slice_axis === :y
-      xlabel = "x"
-      ylabel = "z"
-    elseif slice_axis === :z
-      xlabel = "x"
-      ylabel = "y"
-    else
-      error("illegal dimension '$slice_axis', supported dimensions are :x, :y, and :z")
+  return ContourPlot(x, y, data, variables, xlims, ylims, vertices_x, vertices_y)
+end
+
+
+struct ContourPlotSeries{CP<:ContourPlot}
+  contour_plot::CP
+  variable::String
+end
+
+Base.getindex(cp::ContourPlot, variable) = ContourPlotSeries(cp, variable)
+
+@recipe function f(cps::ContourPlotSeries)
+  cp = cps.contour_plot
+  variable = cps.variable
+
+  if variable != "mesh"
+    variable_id = findfirst(isequal(variable), cp.variables)
+    if isnothing(variable_id)
+      error("variable '$variable' was not found in data set (existing: $(join(cp.variables, ", ")))")
     end
-  elseif ndims == 2
-    xlabel = "x"
-    ylabel = "y"
+  end
+  
+  xlims --> cp.xlims
+  ylims --> cp.ylims
+  aspect_ratio --> :equal
+  legend -->  :none
+
+  # Add data series
+  if cps.variable == "mesh"
+    @series begin
+      seriestype := :path
+      linecolor := :black
+      linewidth := 1
+      cp.vertices_x, cp.vertices_y
+    end
+  else
+    title --> cps.variable
+    colorbar --> :true
+
+    @series begin
+      seriestype := :contour
+      fill --> true
+      linewidth --> 0
+      cp.x, cp.y, transpose(view(cp.data, :, :, variable_id))
+    end
   end
 
-  # Create plot
-  # plot(size=(2000,2000), thickness_scaling=1,
-  #      aspectratio=:equal, legend=:none, title="$label (t = $time)",
-  #      colorbar=true, xlims=xlims, ylims=ylims,
-  #      xlabel=xlabel, ylabel=ylabel,
-  #      labelfontsize=18, tickfontsize=18,
-  #      titlefontsize=28)
+  ()
+end
 
-  # # Plot contours
-  # contourf!(xs, ys, node_centered_data[:, :, variable_id], c=:bluesreds, levels=128, linewidth=0,
-  #           match_dimensions=true)
-
-  # # Plot grid lines
-  # if grid_lines
-  #   plot!(vertices_x, vertices_y, linecolor=:black, linewidth=1, grid=false)
-  # end
-
-  # Create actual plot series and set attributes
-  # size --> ((2000, 2000))
-  # thickness_scaling --> 1
-  aspect_ratio --> :equal
-  # match_dimensions --> true
-  # legend --> :none
-  # colorbar --> true
-  title --> labels[1,1]
-  xlims --> xlims
-  ylims --> ylims
-  xguide --> xlabel
-  yguide --> ylabel
-
-  seriestype --> :contour
-  fill --> true
-  # seriescolor --> :bluesreds
-  # linewidth --> 0
-
-  get_contour_data(center_level_0, length_level_0, leaf_cells, coordinates, levels, ndims, labels,
-                   data, n_nodes, time)
+@recipe function f(cp::ContourPlot)
+  cols = ceil(Int, sqrt(length(cp.variables)))
+  rows = ceil(Int, length(cp.variables)/cols)
+  layout := (rows, cols)
+  for (i, variable) in enumerate(cp.variables)
+    @series begin
+      subplot := i
+      cp[variable]
+    end
+  end
 end
 
 
 function get_contour_data(center_level_0, length_level_0, leaf_cells, coordinates, levels, ndims,
-                          labels, unstructured_data, n_nodes, time)
-  variables = []
-  grid_lines = false
-  nvisnodes = nothing
-  max_supported_level = 11
-  slice_axis = :z
-  slice_axis_intercept = 0
-
+                          unstructured_data, n_nodes,
+                          grid_lines=false, max_supported_level=11, nvisnodes=nothing,
+                          slice_axis=:z, slice_axis_intercept=0)
   # Determine resolution for data interpolation
   max_level = maximum(levels)
   if max_level > max_supported_level
@@ -172,38 +160,36 @@ function get_contour_data(center_level_0, length_level_0, leaf_cells, coordinate
   # Determine element vertices to plot grid lines
   if grid_lines
     vertices_x, vertices_y = calc_vertices(coordinates, levels, length_level_0)
-  end
-
-  # Check that all variables exist in data file
-  if isempty(variables)
-    append!(variables, labels)
   else
-    for var in variables
-      if !(var in labels)
-        error("variable '$var' does not exist in the data file $filename")
-      end
-    end
+    vertices_x = vertices_y = nothing
   end
 
-  variable_id = 1
-  label = variables[variable_id]
-  
-
-  # Create plot
-  # plot(size=(2000,2000), thickness_scaling=1,
-  #      aspectratio=:equal, legend=:none, title="$label (t = $time)",
-  #      colorbar=true, xlims=xlims, ylims=ylims,
-  #      xlabel=xlabel, ylabel=ylabel,
-  #      labelfontsize=18, tickfontsize=18,
-  #      titlefontsize=28)
-
-  # # Plot contours
-  # contourf!(xs, ys, node_centered_data[:, :, variable_id], c=:bluesreds, levels=128, linewidth=0,
-  #           match_dimensions=true)
-
-  # # Plot grid lines
-  # if grid_lines
-  #   plot!(vertices_x, vertices_y, linecolor=:black, linewidth=1, grid=false)
-  # end
-  return xs, ys, transpose(node_centered_data[:, :, variable_id])
+  return xs, ys, node_centered_data, vertices_x, vertices_y
 end
+
+function get_unstructured_data(u, semi, solution_variables)
+  mesh, equations, solver, cache = Trixi.mesh_equations_solver_cache(semi)
+
+  if solution_variables === Trixi.cons2cons
+    raw_data = u
+    n_vars = size(raw_data, 1)
+  else
+    # Reinterpret the solution array as an array of conservative variables,
+    # compute the solution variables via broadcasting, and reinterpret the
+    # result as a plain array of floating point numbers
+    raw_data = Array(reinterpret(eltype(u),
+           solution_variables.(reinterpret(SVector{Trixi.nvariables(equations),eltype(u)}, u),
+                      Ref(equations))))
+    n_vars = size(raw_data, 1)
+  end
+
+  unstructured_data = Array{Float64}(undef,
+                                     ntuple((d) -> Trixi.nnodes(solver), ndims(equations))...,
+                                     Trixi.nelements(solver, cache), n_vars)
+  for variable in 1:n_vars
+    @views unstructured_data[.., :, variable] .= raw_data[variable, .., :]
+  end
+
+  return unstructured_data
+end
+

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -1,0 +1,206 @@
+using RecipesBase
+using DiffEqBase
+import .Trixi
+
+struct TrixiPlot{SolutionT, SemidiscretizationT<:Trixi.AbstractSemidiscretization}
+  u::SolutionT
+  semi::SemidiscretizationT
+end
+
+TrixiPlot(u, prob::ODEProblem) = TrixiPlot(Trixi.wrap_array(u, prob.p), prob.p)
+TrixiPlot(sol::ODESolution) = TrixiPlot(Trixi.wrap_array(sol.u[end], sol.prob.p), sol.prob.p)
+TrixiPlot(u, sol::ODESolution) = TrixiPlot(Trixi.wrap_array(u, sol.prob.p), sol.prob.p)
+TrixiPlot(u, ::Trixi.SemidiscretizationEulerGravity) = error("not implemented")
+
+@recipe function f(tp::TrixiPlot)
+  mesh, equations, solver, cache = Trixi.mesh_equations_solver_cache(semi)
+
+  center_level_0 = mesh.tree.center_level_0
+  length_level_0 = mesh.tree.length_level_0
+  leaf_cells = Trixi.leaf_cells(mesh.tree)
+  coordinates = mesh.tree.coordinates[:, leaf_cells]
+  levels = mesh.tree.levels[leaf_cells]
+  ndims = Trixi.ndims(mesh)
+
+  labels = Array{String}(undef, 1, Trixi.nvariables(equations))
+  labels[1, :] .= Trixi.varnames(Trixi.cons2cons, equations)
+  if ndims == 3
+    # Read 3d data
+    data = Array{Float64}(undef, Trixi.nnodes(solver), Trixi.nnodes(solver), Trixi.nnodes(solver),
+                          Trixi.nelements(solver, cache), Trixi.nvariables(equations))
+  elseif ndims == 2
+    # Read 2d data
+    data = Array{Float64}(undef, Trixi.nnodes(solver), Trixi.nnodes(solver),
+                          Trixi.nelements(solver, cache), Trixi.nvariables(equations))
+  else
+    error("unsupported number of dimensions: $ndims")
+  end
+  for variable in eachvariables(equations)
+    @views data[.., :, variable] .= tp.u[variable, .., :]
+  end
+  n_nodes = Trixi.nnodes(solver)
+  time = 0.0
+
+  # Calculate x and y limits
+  xlims_ = (-1, 1) .* (length_level_0/2 + center_level_0[1])
+  ylims_ = (-1, 1) .* (length_level_0/2 + center_level_0[2])
+
+  # Determine axis labels
+  if ndims == 3
+    # Extract plot labels
+    if slice_axis === :x
+      xlabel_ = "y"
+      ylabel_ = "z"
+    elseif slice_axis === :y
+      xlabel_ = "x"
+      ylabel_ = "z"
+    elseif slice_axis === :z
+      xlabel_ = "x"
+      ylabel_ = "y"
+    else
+      error("illegal dimension '$slice_axis', supported dimensions are :x, :y, and :z")
+    end
+  elseif ndims == 2
+    xlabel_ = "x"
+    ylabel_ = "y"
+  end
+
+  # Create plot
+  # plot(size=(2000,2000), thickness_scaling=1,
+  #      aspectratio=:equal, legend=:none, title="$label (t = $time)",
+  #      colorbar=true, xlims=xlims, ylims=ylims,
+  #      xlabel=xlabel, ylabel=ylabel,
+  #      labelfontsize=18, tickfontsize=18,
+  #      titlefontsize=28)
+
+  # # Plot contours
+  # contourf!(xs, ys, node_centered_data[:, :, variable_id], c=:bluesreds, levels=128, linewidth=0,
+  #           match_dimensions=true)
+
+  # # Plot grid lines
+  # if grid_lines
+  #   plot!(vertices_x, vertices_y, linecolor=:black, linewidth=1, grid=false)
+  # end
+
+  # Create actual plot series and set attributes
+  size --> ((2000, 2000))
+  thickness_scaling --> 1
+  aspectratio --> :equal
+  legend --> :none
+  title --> "$(labels[1,1])"
+  colorbar --> true
+  xlims --> xlims_
+  ylims --> ylims_
+  xlabel --> xlabel_
+  ylabel --> ylabel_
+  labelfontsize --> 18
+  tickfontsize --> 18
+  titlefontsize --> 28
+
+  seriestype --> :contour
+  fill --> true
+  c --> :bluesreds
+  levels --> 128
+  linewidth --> 0
+  match_dimensions --> true
+
+  get_contour_data(center_level_0, length_level_0, leaf_cells, coordinates, levels, ndims, labels,
+                   unstructured_data, n_nodes, time)
+end
+
+
+function get_contour_data(center_level_0, length_level_0, leaf_cells, coordinates, levels, ndims,
+                          labels, unstructured_data, n_nodes, time)
+  variables = []
+  grid_lines = false
+  nvisnodes = nothing
+  max_supported_level = 11
+  slice_axis = :z
+  slice_axis_intercept = 0
+
+  # Determine resolution for data interpolation
+  max_level = maximum(levels)
+  if max_level > max_supported_level
+    error("Maximum refinement level in data file $max_level is higher than " *
+          "maximum supported level $max_supported_level")
+  end
+  max_available_nodes_per_finest_element = 2^(max_supported_level - max_level)
+  if nvisnodes === nothing
+    max_nvisnodes = 2 * n_nodes
+  elseif nvisnodes == 0
+    max_nvisnodes = n_nodes
+  else
+    max_nvisnodes = nvisnodes
+  end
+  nvisnodes_at_max_level = min(max_available_nodes_per_finest_element, max_nvisnodes)
+  resolution = nvisnodes_at_max_level * 2^max_level
+  nvisnodes_per_level = [2^(max_level - level)*nvisnodes_at_max_level for level in 0:max_level]
+  # nvisnodes_per_level is an array (accessed by "level + 1" to accommodate
+  # level-0-cell) that contains the number of visualization nodes for any
+  # refinement level to visualize on an equidistant grid
+
+  if ndims == 3
+    (unstructured_data, coordinates, levels,
+        center_level_0) = unstructured_2d_to_3d(unstructured_data,
+        coordinates, levels, length_level_0, center_level_0, slice_axis,
+        slice_axis_intercept)
+  end
+
+  # Normalize element coordinates: move center to (0, 0) and domain size to [-1, 1]²
+  n_elements = length(levels)
+  normalized_coordinates = similar(coordinates)
+  for element_id in 1:n_elements
+    @views normalized_coordinates[:, element_id] .= (
+          (coordinates[:, element_id] .- center_level_0) ./ (length_level_0 / 2 ))
+  end
+
+  # Interpolate unstructured DG data to structured data
+  (structured_data =
+      unstructured2structured(unstructured_data, normalized_coordinates,
+                              levels, resolution, nvisnodes_per_level))
+
+  # Interpolate cell-centered values to node-centered values
+  node_centered_data = cell2node(structured_data)
+
+  # Determine axis coordinates for contour plot
+  xs = collect(range(-1, 1, length=resolution+1)) .* length_level_0/2 .+ center_level_0[1]
+  ys = collect(range(-1, 1, length=resolution+1)) .* length_level_0/2 .+ center_level_0[2]
+
+  # Determine element vertices to plot grid lines
+  if grid_lines
+    vertices_x, vertices_y = calc_vertices(coordinates, levels, length_level_0)
+  end
+
+  # Check that all variables exist in data file
+  if isempty(variables)
+    append!(variables, labels)
+  else
+    for var in variables
+      if !(var in labels)
+        error("variable '$var' does not exist in the data file $filename")
+      end
+    end
+  end
+
+  variable_id = 1
+  label = variables[variable_id]
+  
+
+  # Create plot
+  # plot(size=(2000,2000), thickness_scaling=1,
+  #      aspectratio=:equal, legend=:none, title="$label (t = $time)",
+  #      colorbar=true, xlims=xlims, ylims=ylims,
+  #      xlabel=xlabel, ylabel=ylabel,
+  #      labelfontsize=18, tickfontsize=18,
+  #      titlefontsize=28)
+
+  # # Plot contours
+  # contourf!(xs, ys, node_centered_data[:, :, variable_id], c=:bluesreds, levels=128, linewidth=0,
+  #           match_dimensions=true)
+
+  # # Plot grid lines
+  # if grid_lines
+  #   plot!(vertices_x, vertices_y, linecolor=:black, linewidth=1, grid=false)
+  # end
+  return xs, ys, node_centered_data[:, :, variable_id]
+end


### PR DESCRIPTION
Partially fixes trixi-framework/Trixi.jl#350.

**Update: Deprecated in favor of trixi-framework/Trixi.jl#384**

This is an initial attempt to add native plotting support with Plots.jl to Trixi. The idea is to wrap a Trixi solution in a `ContourPlot` type, which does all necessary conversions, and then plot individual variables using a `dict`-like syntax on the `ContourPlot` variable. But examples speak louder than words...

**Generate data (needs to have current Trixi package installed)**
```julia
julia> using Revise; using Trixi

julia> trixi_include(joinpath(examples_dir(), "2d", "elixir_euler_blast_wave_amr.jl"), tspan=(0,2))
```

**Create plots**
```julia
julia> using Trixi2Img, Plots

julia> cp = ContourPlot(sol, solution_variables=cons2prim); # Pass `ODESolution` to `ContourPlot`, use Trixi's `cons2prim` to get primitive variables

julia> plot(cp) # Plot overview of all variables

julia> plot(cp["p"], c=:redsblues) # Plot only pressure and with different color scheme

julia> plot!(cp["mesh"]) # Add mesh lines to pressure plot
```

Result of `plot(cp)`:
![image](https://user-images.githubusercontent.com/3637659/101629294-69e6d780-3a21-11eb-8733-c790d6111a7c.png)

Result of `plot(cp["p"], c=:redsblues); plot!(cp["mesh"])`
![image](https://user-images.githubusercontent.com/3637659/101629452-a87c9200-3a21-11eb-9eea-9667e1b06604.png)

At the moment this is mostly a proof-of-concept, and I am looking for feedback and suggestions on how to improve this. There are many issues to discuss (also some rather fundamental ones), so maybe it's better to do it face-to-face at one of the next meetings and then work out the details here.